### PR TITLE
Added support for collection and array

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,6 +97,10 @@ To push to multiple devices:
 PushBullet::device('Chrome')->device('Galaxy S4')->note('Remember', 'Buy some eggs.');
 // or
 PushBullet::device('Chrome', 'Galaxy S4')->note('Remember', 'Buy some eggs.');
+// or using an array
+PushBullet::device(['Chrome', 'Galaxy S4'])->note('Remember', 'Buy some eggs.');
+// or using a collection
+PushBullet::device(Device::all()->pluck('name'))->note('Remember', 'Buy some eggs.');
 ```
 
 If you want to push to all devices
@@ -114,6 +118,10 @@ PushBullet::type('android')->note('Remember', 'Buy some eggs.');
 PushBullet::type('android')->type('chrome')->note('Remember', 'Buy some eggs.');
 // or
 PushBullet::type('android', 'chrome')->note('Remember', 'Buy some eggs.');
+// or using an array
+PushBullet::type(['android', 'chrome'])->note('Remember', 'Buy some eggs.');
+// or using a collection
+PushBullet::type(Type::all()->pluck('name'))->note('Remember', 'Buy some eggs.');
 ```
 
 
@@ -134,6 +142,10 @@ To push to multiple users:
 PushBullet::user('joe@example.com')->user('anne@example.com')->note('Remember', 'Buy some eggs.');
 // or
 PushBullet::user('joe@example.com', 'anne@example.com')->note('Remember', 'Buy some eggs.');
+// or using an array
+PushBullet::user(['joe@example.com', 'anne@example.com'])->note('Remember', 'Buy some eggs.');
+// or using a collection
+PushBullet::user(User::findMany([1, 2, 3])->pluck('email'))->note('Remember', 'Buy some eggs.');
 ```
 ## Types
 

--- a/src/LaravelPushbullet.php
+++ b/src/LaravelPushbullet.php
@@ -1,5 +1,6 @@
 <?php namespace Lahaxearnaud\LaravelPushbullet;
 
+use Illuminate\Database\Eloquent\Collection;
 use PHPushbullet\PHPushbullet;
 
 class LaravelPushbullet extends PHPushbullet {
@@ -24,9 +25,28 @@ class LaravelPushbullet extends PHPushbullet {
         return $this;
     }
 
+    public function device()
+    {
+        if (func_get_arg(0) instanceof Collection) {
+            $args = func_get_arg(0)->toArray();
+        } elseif (is_array(func_get_arg(0))) {
+            $args = func_get_arg(0);
+        } else {
+            $args = func_get_args();
+        }
+
+        return call_user_func_array(['parent', 'device'], $args);
+    }
+
     public function type()
     {
-        foreach (func_get_args() as $type) {
+        if (func_get_arg(0) instanceof Collection || is_array(func_get_arg(0))) {
+            $args = func_get_arg(0);
+        } else {
+            $args = func_get_args();
+        }
+
+        foreach ($args as $type) {
             $devices = $this->devices();
             foreach ($devices as $device) {
                 if(strcasecmp($device->type, $type) === 0 && $device->active) {
@@ -40,5 +60,18 @@ class LaravelPushbullet extends PHPushbullet {
         }
 
         return $this;
+    }
+
+    public function user()
+    {
+        if (func_get_arg(0) instanceof Collection) {
+            $args = func_get_arg(0)->toArray();
+        } elseif (is_array(func_get_arg(0))) {
+            $args = func_get_arg(0);
+        } else {
+            $args = func_get_args();
+        }
+
+        return call_user_func_array(['parent', 'user'], $args);
     }
 }


### PR DESCRIPTION
Regardless of `phpushbullet` implementation.

No matter which form of arguments is sent (single, array, collection), the arguments will be resent as "successive arguments". Ex:

    PushBullet::user([foo, bar])
    // OR
    PushBullet::user([foo, bar])
    // OR
    PushBullet::user(collection([foo, bar]))

Will all call:

    parent::user('foo', 'bar')