### PR TITLE
Fixed typo in Collection class name

### DIFF
--- a/src/LaravelPushbullet.php
+++ b/src/LaravelPushbullet.php
@@ -1,6 +1,6 @@
 <?php namespace Lahaxearnaud\LaravelPushbullet;
 
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use PHPushbullet\PHPushbullet;
 
 class LaravelPushbullet extends PHPushbullet {


### PR DESCRIPTION
`Illuminate\Database\Eloquent\Collection` extends `Illuminate\Support\Collection`