### PR TITLE
Send default option to constructor

### DIFF
--- a/src/LaravelPushbullet.php
+++ b/src/LaravelPushbullet.php
@@ -7,9 +7,7 @@ class LaravelPushbullet extends PHPushbullet {
 
     public function __construct($access_token = null)
     {
-        parent::__construct($access_token);
-
-        $this->api->setDefaultOption('verify', false);
+        parent::__construct($access_token, null, ['verify' => false]);
     }
 
 


### PR DESCRIPTION
On `Guzzle 6`, default options can’t be set outside the constructor.
Passing options to the constructor is working on `5.3` and `6.0`

Fixes: https://github.com/lahaxearnaud/laravel-pushbullet/issues/9, but depends on this PR: https://github.com/joetannenbaum/phpushbullet/pull/8